### PR TITLE
Fix data-integrity bugs: BOM merge corruption, lost debounced saves, orphaned BOM keys on rename

### DIFF
--- a/script.js
+++ b/script.js
@@ -2726,24 +2726,32 @@ function mergeDuplicateInventoryEntries(showNotifications = true) {
     }
     
     // Update project BOMs to use canonical IDs
+    // BOM entries are objects: { name, quantity }. Entries pointing at merged
+    // duplicates are remapped to the canonical ID (summing quantities if both
+    // exist); entries with no canonical match are kept as-is, since a BOM may
+    // legitimately reference parts that aren't in the inventory yet.
     for (const project of Object.values(projects)) {
         if (project.bom) {
             const updatedBom = {};
-            for (const [id, quantity] of Object.entries(project.bom)) {
-                // Check if the inventory item still exists
-                if (inventory[id]) {
-                    const normalizedId = normalizeValue(inventory[id].name || '');
-                    const canonicalId = normalizedToCanonical[normalizedId];
-                    if (canonicalId && inventory[canonicalId]) {
-                        updatedBom[canonicalId] = (updatedBom[canonicalId] || 0) + quantity;
-                    }
+            for (const [id, entry] of Object.entries(project.bom)) {
+                const isObjectEntry = entry && typeof entry === 'object';
+                const entryName = isObjectEntry ? entry.name : undefined;
+                // Tolerate legacy numeric entries by coercing them to a quantity
+                const entryQuantity = isObjectEntry ? (entry.quantity || 0) : (Number(entry) || 0);
+                
+                // Resolve the canonical ID via the part's name if it's in inventory,
+                // otherwise via the BOM entry's own name or raw ID
+                const lookupName = inventory[id] ? (inventory[id].name || '') : (entryName || id);
+                const canonicalId = normalizedToCanonical[normalizeValue(lookupName)] ||
+                    normalizedToCanonical[normalizeValue(id)];
+                
+                const targetId = (canonicalId && inventory[canonicalId]) ? canonicalId : id;
+                const targetName = (inventory[targetId] && inventory[targetId].name) || entryName || id;
+                
+                if (updatedBom[targetId]) {
+                    updatedBom[targetId].quantity = (updatedBom[targetId].quantity || 0) + entryQuantity;
                 } else {
-                    // If the original part doesn't exist, try to find a canonical match by ID
-                    const normalizedId = normalizeValue(id);
-                    const canonicalId = normalizedToCanonical[normalizedId];
-                    if (canonicalId && inventory[canonicalId]) {
-                        updatedBom[canonicalId] = (updatedBom[canonicalId] || 0) + quantity;
-                    }
+                    updatedBom[targetId] = { name: targetName, quantity: entryQuantity };
                 }
             }
             project.bom = updatedBom;

--- a/script.js
+++ b/script.js
@@ -409,11 +409,17 @@ function normalizeValue(str) {
     return normalized;
 }
 
+// Dirty flags so pending debounced saves can be flushed if the page is
+// hidden or closed before the debounce timer fires
+let inventoryDirty = false;
+let projectsDirty = false;
+
 /**
  * Save projects data to browser's local storage
  * Persists project information including BOMs between browser sessions
  */
 function saveProjects() {
+    projectsDirty = true;
     debouncedSaveProjects();
 }
 
@@ -422,6 +428,7 @@ function saveProjects() {
  * Persists component inventory between browser sessions
  */
 function saveInventory() {
+    inventoryDirty = true;
     debouncedSaveInventory();
 }
 
@@ -3250,8 +3257,8 @@ function detectDevicePerformance() {
 // LOCALSTORAGE PERFORMANCE OPTIMIZATIONS
 // =============================================================================
 
-// Debounced save functions to prevent excessive localStorage writes
-const debouncedSaveInventory = debounce(() => {
+// Synchronous writers used by both the debounced saves and the unload flush
+function writeInventoryToStorage() {
     try {
         const compressed = compressData(inventory);
         localStorage.setItem('guitarPedalInventory', compressed);
@@ -3260,9 +3267,10 @@ const debouncedSaveInventory = debounce(() => {
         // Fallback to uncompressed if compression fails
         localStorage.setItem('guitarPedalInventory', JSON.stringify(inventory));
     }
-}, 1000);
+    inventoryDirty = false;
+}
 
-const debouncedSaveProjects = debounce(() => {
+function writeProjectsToStorage() {
     try {
         const compressed = compressData(projects);
         localStorage.setItem('guitarPedalProjects', compressed);
@@ -3271,7 +3279,28 @@ const debouncedSaveProjects = debounce(() => {
         // Fallback to uncompressed if compression fails
         localStorage.setItem('guitarPedalProjects', JSON.stringify(projects));
     }
-}, 1000);
+    projectsDirty = false;
+}
+
+// Debounced save functions to prevent excessive localStorage writes
+const debouncedSaveInventory = debounce(writeInventoryToStorage, 1000);
+const debouncedSaveProjects = debounce(writeProjectsToStorage, 1000);
+
+// Flush any pending debounced saves immediately so edits made within the
+// debounce window aren't lost when the tab is hidden, closed, or navigated away
+function flushPendingSaves() {
+    if (inventoryDirty) writeInventoryToStorage();
+    if (projectsDirty) writeProjectsToStorage();
+}
+
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+        flushPendingSaves();
+    }
+});
+
+// pagehide covers browsers/situations where visibilitychange doesn't fire on close
+window.addEventListener('pagehide', flushPendingSaves);
 
 // Simple compression for localStorage
 function compressData(data) {

--- a/script.js
+++ b/script.js
@@ -1228,6 +1228,7 @@ function saveEditPart() {
         showNotification('Part ID already exists', 'error');
         return;
     }
+    const previousPartId = editingPartId;
     if (newId !== editingPartId) {
         const part = inventory[editingPartId];
         inventory[newId] = {
@@ -1263,6 +1264,11 @@ function saveEditPart() {
     // Update project BOMs
     for (const projectId in projects) {
         if (!projects[projectId].bom) projects[projectId].bom = {};
+        // If the part ID changed, remove the entry stored under the old ID
+        // so BOMs don't keep orphaned references to it
+        if (newId !== previousPartId) {
+            delete projects[projectId].bom[previousPartId];
+        }
         if (newProjects[projectId]) {
             projects[projectId].bom[newId] = {
                 name: newName,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First of a planned series of improvement branches. This one fixes three bugs that corrupt or lose user data, each in its own commit.

### 1. BOM corruption in `mergeDuplicateInventoryEntries()`

Project BOM entries are `{ name, quantity }` objects everywhere in the app, but the duplicate-merge routine treated them as plain numbers:

```js
updatedBom[canonicalId] = (updatedBom[canonicalId] || 0) + quantity; // quantity is an object!
```

This produced strings like `"0[object Object]"`, silently destroying BOM entries whenever the automatic merge ran on load or after an import and duplicates existed. The remap pass now preserves the object shape, sums quantities when two entries collapse onto the same canonical part, keeps BOM entries that reference parts not present in inventory (previously silently dropped), and coerces legacy numeric entries instead of corrupting them.

### 2. Edits lost when closing the tab within the save debounce window

`saveInventory()`/`saveProjects()` debounce localStorage writes by 1 second with no flush on exit, so a quantity change followed by closing the tab was lost. The writers are now extracted into synchronous functions with dirty-state tracking, and pending writes are flushed on `visibilitychange` (hidden) and `pagehide`.

### 3. Orphaned BOM entries when a part's ID is renamed

`saveEditPart()` moved the inventory record to the new key but left project BOMs holding entries under the old part ID, so projects reported parts as missing even though they were in stock under the new ID. The old-ID entry is now removed from every project BOM when the ID changes.

## Testing

- `node --check script.js` passes.
- Verified with a Node harness that loads `script.js` with stubbed browser globals and exercises all three fixes (19 assertions, all passing). Run against the unmodified `main` version of `script.js`, the same harness reproduces the bugs: BOM entries become `"0[object Object]"` after merge, and no flush listeners are registered.
- The harness is a throwaway verification script (the repo has no test infrastructure yet); happy to add it as a committed test if a `package.json`/test setup is introduced later.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f29-da8f-7986-9825-da90ccf32040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f29-da8f-7986-9825-da90ccf32040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

