### PR TITLE
XSS hardening: escape user data in all HTML templates, remove injectable inline handlers, validate purchase URLs

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,6 +52,43 @@ function escapeHtml(str) {
 }
 
 /**
+ * Check that a URL is safe to open or save as a purchase link.
+ * Only http: and https: are allowed (blocks javascript:, data:, etc.).
+ * @param {string} url - URL to validate
+ * @returns {boolean} True if the URL parses and uses http(s)
+ */
+function isSafeHttpUrl(url) {
+    if (typeof url !== 'string' || !url) return false;
+    try {
+        const parsed = new URL(url);
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
+ * Normalize a user-entered purchase URL for storage.
+ * Adds https:// to scheme-less input like "www.mouser.com/...".
+ * Returns '' for anything that still isn't a valid http(s) URL.
+ * @param {string} url - Raw user input
+ * @returns {string} A safe http(s) URL, or ''
+ */
+function sanitizePurchaseUrl(url) {
+    if (typeof url !== 'string') return '';
+    const trimmed = url.trim();
+    if (!trimmed) return '';
+    if (isSafeHttpUrl(trimmed)) return trimmed;
+    // Tolerate scheme-less input (the old code stored it as-is,
+    // which produced a broken relative link anyway)
+    if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) {
+        const withScheme = 'https://' + trimmed;
+        if (isSafeHttpUrl(withScheme)) return withScheme;
+    }
+    return '';
+}
+
+/**
  * Generic utility function to copy text to clipboard
  * Uses modern clipboard API with fallback to execCommand
  * @param {string} text - Text to copy to clipboard
@@ -582,6 +619,20 @@ function exportInventory(format) {
     showNotification(`Saved inventory to ${filename}`);
 }
 
+/**
+ * Drop non-http(s) purchase URLs from imported inventory data.
+ * Imported files are untrusted; a javascript: URL here would execute
+ * when the user clicks the part's shop button.
+ */
+function sanitizeImportedPurchaseUrls(inventoryData) {
+    for (const partId in inventoryData) {
+        const part = inventoryData[partId];
+        if (part && part.purchaseUrl) {
+            part.purchaseUrl = sanitizePurchaseUrl(String(part.purchaseUrl));
+        }
+    }
+}
+
 function importInventory(event) {
     const file = event.target.files[0];
     if (!file) return;
@@ -632,6 +683,7 @@ function importInventory(event) {
             if (importedData.inventory && importedData.projects) {
                 inventory = importedData.inventory;
                 projects = importedData.projects;
+                sanitizeImportedPurchaseUrls(inventory);
                 // Auto-merge duplicates after import (silently)
                 mergeDuplicateInventoryEntries(false);
                 saveProjects();
@@ -639,6 +691,7 @@ function importInventory(event) {
             } else if (typeof importedData === 'object' && importedData !== null) {
                 // Fallback for old format or CSV import
                 inventory = importedData;
+                sanitizeImportedPurchaseUrls(inventory);
                 // --- Begin: Ensure projects are globally tagged and BOMs updated ---
                 for (const partId in inventory) {
                     const part = inventory[partId];
@@ -1220,11 +1273,16 @@ function saveEditPart() {
     if (!editingPartId) return;
     const newName = document.getElementById('editPartName').value.trim();
     const newQuantity = parseInt(document.getElementById('editPartQuantity').value) || 0;
-    const newUrl = document.getElementById('editPartUrl').value.trim();
+    const rawNewUrl = document.getElementById('editPartUrl').value.trim();
+    const newUrl = sanitizePurchaseUrl(rawNewUrl);
     let newId = document.getElementById('editPartId').value.trim();
     const newType = document.getElementById('editPartType').value;
     if (!newName) {
         showNotification('Please enter a part name', 'error');
+        return;
+    }
+    if (rawNewUrl && !newUrl) {
+        showNotification('Purchase link must be a valid http(s) URL', 'error');
         return;
     }
     // Generate ID: normalize name + _ + normalize type (if type is selected)
@@ -1327,7 +1385,12 @@ function confirmDeletePart() {
 function addNewPart() {
     const name = document.getElementById('newPartName').value.trim();
     const quantity = parseInt(document.getElementById('newPartQuantity').value) || 0;
-    const purchaseUrl = document.getElementById('newPartUrl').value.trim();
+    const rawPurchaseUrl = document.getElementById('newPartUrl').value.trim();
+    const purchaseUrl = sanitizePurchaseUrl(rawPurchaseUrl);
+    if (rawPurchaseUrl && !purchaseUrl) {
+        showNotification('Purchase link must be a valid http(s) URL', 'error');
+        return;
+    }
     let id = document.getElementById('newPartId').value.trim();
     const type = document.getElementById('newPartType').value;
     
@@ -1395,7 +1458,14 @@ function addNewPart() {
 function handlePurchaseClick(partId) {
     const part = inventory[partId];
     if (part && part.purchaseUrl) {
-        window.open(part.purchaseUrl, '_blank');
+        // Validate at click time too: URLs may come from imported files
+        // saved before sanitization existed
+        const safeUrl = sanitizePurchaseUrl(part.purchaseUrl);
+        if (!safeUrl) {
+            showNotification('Purchase link is not a valid web address', 'error');
+            return;
+        }
+        window.open(safeUrl, '_blank', 'noopener');
     } else {
         showNotification('No purchase link available', 'error');
     }
@@ -2104,7 +2174,7 @@ function addMissingParts() {
             inventory[id] = {
                 name: part.name,
                 quantity: 0,
-                purchaseUrl: part.purchaseUrl || '',
+                purchaseUrl: sanitizePurchaseUrl(part.purchaseUrl || ''),
                 projects: {}
             };
             addedCount++;

--- a/script.js
+++ b/script.js
@@ -35,15 +35,20 @@ function debounce(func, wait) {
 }
 
 /**
- * Escape HTML to prevent XSS attacks
+ * Escape HTML to prevent XSS attacks.
+ * Also escapes quotes so the result is safe inside double- or
+ * single-quoted attribute values, not just text content.
  * @param {string} str - String to escape
  * @returns {string} HTML-escaped string
  */
 function escapeHtml(str) {
     if (typeof str !== 'string') return str;
-    const div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }
 
 /**
@@ -846,7 +851,7 @@ function createInventoryItemElement(id, part) {
         if (isMobile) {
             // On mobile, always show a clickable tag for projects
             projectTagsHtml = `
-                <span class="project-tag more-tags" data-part-id="${id}" title="Show all projects">
+                <span class="project-tag more-tags" data-part-id="${escapeHtml(id)}" title="Show all projects">
                     +${projectEntries.length} project${projectEntries.length > 1 ? 's' : ''}
                 </span>
             `;
@@ -854,8 +859,8 @@ function createInventoryItemElement(id, part) {
             projectTagsHtml = projectEntries.slice(0, maxTags).map(([projectId, qty]) => {
                 const project = projects[projectId];
                 return project ? `
-                    <span class="project-tag" data-project-id="${projectId}" title="${project.name} (${qty} needed)">
-                        ${project.name.length > 12 ? project.name.slice(0, 10) + '…' : project.name} (${qty})
+                    <span class="project-tag" data-project-id="${escapeHtml(projectId)}" title="${escapeHtml(project.name)} (${qty} needed)">
+                        ${escapeHtml(project.name.length > 12 ? project.name.slice(0, 10) + '…' : project.name)} (${qty})
                     </span>
                 ` : '';
             }).join('');
@@ -863,7 +868,7 @@ function createInventoryItemElement(id, part) {
             if (projectEntries.length > maxTags) {
                 const moreCount = projectEntries.length - maxTags;
                 projectTagsHtml += `
-                    <span class="project-tag more-tags" data-part-id="${id}" title="Show all projects">+${moreCount} more</span>
+                    <span class="project-tag more-tags" data-part-id="${escapeHtml(id)}" title="Show all projects">+${moreCount} more</span>
                 `;
             }
         }
@@ -873,10 +878,11 @@ function createInventoryItemElement(id, part) {
     let typePillHtml = '';
     const isCap = /\b(capacitor|cap)\b/i.test(part.name);
     if (isCap && part.type) {
-        const typeClass = part.type.toLowerCase().replace(/\s/g, '');
-        typePillHtml = `<span class="type-pill ${typeClass}">${part.type}</span>`;
+        // Restrict the CSS class to safe characters; the visible label is escaped
+        const typeClass = part.type.toLowerCase().replace(/[^a-z0-9_-]/g, '');
+        typePillHtml = `<span class="type-pill ${typeClass}">${escapeHtml(part.type)}</span>`;
     } else if (isCap && !part.type) {
-        typePillHtml = `<span class="set-type-pill" data-set-type="${id}" title="Set capacitor type">Set Type</span>`;
+        typePillHtml = `<span class="set-type-pill" title="Set capacitor type">Set Type</span>`;
     }
 
     // Responsive: type pill below name on mobile, inline on desktop
@@ -896,13 +902,13 @@ function createInventoryItemElement(id, part) {
                     <button class="quantity-btn" data-action="increase">+</button>
                 </div>
                 <div class="item-actions">
-                    <button class="action-icon edit-icon" onclick="showEditPartModal('${id}')" title="Edit part">
+                    <button class="action-icon edit-icon" title="Edit part">
                         <svg viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>
                     </button>
-                    <button class="action-icon delete-icon" onclick="showDeletePartModal('${id}')" title="Delete part">
+                    <button class="action-icon delete-icon" title="Delete part">
                         <svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>
                     </button>
-                    <button class="action-icon shop-icon" onclick="handlePurchaseClick('${id}')" title="Open purchase link">
+                    <button class="action-icon shop-icon" title="Open purchase link">
                         <svg viewBox="0 0 24 24"><path d="M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-8 4c0 .55-.45 1-1 1s-1-.45-1-1V8h2v2zm2-6c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm4 6c0 .55-.45 1-1 1s-1-.45-1-1V8h2v2z"/></svg>
                     </button>
                 </div>
@@ -923,13 +929,13 @@ function createInventoryItemElement(id, part) {
                 <button class="quantity-btn" data-action="increase">+</button>
             </div>
             <div class="item-actions">
-                <button class="action-icon edit-icon" onclick="showEditPartModal('${id}')" title="Edit part">
+                <button class="action-icon edit-icon" title="Edit part">
                     <svg viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>
                 </button>
-                <button class="action-icon delete-icon" onclick="showDeletePartModal('${id}')" title="Delete part">
+                <button class="action-icon delete-icon" title="Delete part">
                     <svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>
                 </button>
-                <button class="action-icon shop-icon" onclick="handlePurchaseClick('${id}')" title="Open purchase link">
+                <button class="action-icon shop-icon" title="Open purchase link">
                     <svg viewBox="0 0 24 24"><path d="M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-8 4c0 .55-.45 1-1 1s-1-.45-1-1V8h2v2zm2-6c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm4 6c0 .55-.45 1-1 1s-1-.45-1-1V8h2v2z"/></svg>
                 </button>
             </div>
@@ -942,6 +948,15 @@ function createInventoryItemElement(id, part) {
     
     if (decreaseBtn) decreaseBtn.addEventListener('click', () => adjustStockInline(id, 'remove'));
     if (increaseBtn) increaseBtn.addEventListener('click', () => adjustStockInline(id, 'add'));
+
+    // Action buttons (previously inline onclick handlers, which allowed
+    // JS injection via crafted part IDs)
+    const editBtn = item.querySelector('.edit-icon');
+    const deleteBtn = item.querySelector('.delete-icon');
+    const shopBtn = item.querySelector('.shop-icon');
+    if (editBtn) editBtn.addEventListener('click', () => showEditPartModal(id));
+    if (deleteBtn) deleteBtn.addEventListener('click', () => showDeletePartModal(id));
+    if (shopBtn) shopBtn.addEventListener('click', () => handlePurchaseClick(id));
 
     // Add project tag click handlers
     const projectTags = item.querySelectorAll('.project-tag');
@@ -1087,17 +1102,17 @@ function populateEditPartProjectsSection(partId) {
         
         projectsHtml += `
             <div class="nord-project-inv-row">
-                <span class="nord-project-inv-name" title="${project.name}">${project.name}</span>
+                <span class="nord-project-inv-name" title="${escapeHtml(project.name)}">${escapeHtml(project.name)}</span>
                 <div class="modal-item-quantity">
-                    <button type="button" class="quantity-btn" onclick="adjustProjectQty('${projectId}', -1)">-</button>
+                    <button type="button" class="quantity-btn" data-qty-delta="-1">-</button>
                     <input type="number" 
                            class="edit-project-qty" 
-                           data-project-qty="${projectId}" 
-                           value="${currentQty}" 
+                           data-project-qty="${escapeHtml(projectId)}" 
+                           value="${Number(currentQty) || 0}" 
                            min="0" 
                            max="9999"
                            style="width: 60px; text-align: center; background: var(--nord2); color: var(--nord6); border: 1px solid var(--nord4); padding: 4px;">
-                    <button type="button" class="quantity-btn" onclick="adjustProjectQty('${projectId}', 1)">+</button>
+                    <button type="button" class="quantity-btn" data-qty-delta="1">+</button>
                 </div>
             </div>
         `;
@@ -1114,6 +1129,25 @@ function populateEditPartProjectsSection(partId) {
     `;
     
     projectsSection.innerHTML = projectsHtml;
+    attachQtyDeltaHandler(projectsSection);
+}
+
+/**
+ * Delegated click handler for the +/- buttons in modal project rows.
+ * Adjusts the sibling number input directly, so no project IDs need to
+ * be embedded in inline handlers or query selectors.
+ * Uses .onclick assignment so repeated modal opens don't stack listeners.
+ */
+function attachQtyDeltaHandler(container) {
+    container.onclick = (e) => {
+        const btn = e.target.closest('[data-qty-delta]');
+        if (!btn || !container.contains(btn)) return;
+        const input = btn.parentElement.querySelector('input[type="number"]');
+        if (!input) return;
+        const delta = parseInt(btn.getAttribute('data-qty-delta'), 10) || 0;
+        const currentValue = parseInt(input.value) || 0;
+        input.value = Math.max(0, Math.min(9999, currentValue + delta));
+    };
 }
 
 function populateNewPartProjectsSection() {
@@ -1146,17 +1180,17 @@ function populateNewPartProjectsSection() {
         
         projectsHtml += `
             <div class="nord-project-inv-row">
-                <span class="nord-project-inv-name" title="${project.name}">${project.name}</span>
+                <span class="nord-project-inv-name" title="${escapeHtml(project.name)}">${escapeHtml(project.name)}</span>
                 <div class="modal-item-quantity">
-                    <button type="button" class="quantity-btn" onclick="adjustNewProjectQty('${projectId}', -1)">-</button>
+                    <button type="button" class="quantity-btn" data-qty-delta="-1">-</button>
                     <input type="number" 
                            class="new-project-qty" 
-                           data-new-project-qty="${projectId}" 
+                           data-new-project-qty="${escapeHtml(projectId)}" 
                            value="0" 
                            min="0" 
                            max="9999"
                            style="width: 60px; text-align: center; background: var(--nord2); color: var(--nord6); border: 1px solid var(--nord4); padding: 4px;">
-                    <button type="button" class="quantity-btn" onclick="adjustNewProjectQty('${projectId}', 1)">+</button>
+                    <button type="button" class="quantity-btn" data-qty-delta="1">+</button>
                 </div>
             </div>
         `;
@@ -1173,24 +1207,7 @@ function populateNewPartProjectsSection() {
     `;
     
     projectsSection.innerHTML = projectsHtml;
-}
-
-function adjustProjectQty(projectId, delta) {
-    const input = document.querySelector(`[data-project-qty="${projectId}"]`);
-    if (input) {
-        const currentValue = parseInt(input.value) || 0;
-        const newValue = Math.max(0, Math.min(9999, currentValue + delta));
-        input.value = newValue;
-    }
-}
-
-function adjustNewProjectQty(projectId, delta) {
-    const input = document.querySelector(`[data-new-project-qty="${projectId}"]`);
-    if (input) {
-        const currentValue = parseInt(input.value) || 0;
-        const newValue = Math.max(0, Math.min(9999, currentValue + delta));
-        input.value = newValue;
-    }
+    attachQtyDeltaHandler(projectsSection);
 }
 
 function hideEditPartModal() {
@@ -1589,7 +1606,7 @@ function showProjectDetails(projectId) {
                 if (normalizeValue(invId) === normId) {
                     part = inventory[invId];
                     matchedId = invId;
-                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${part.name})</span>`;
+                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${escapeHtml(part.name)})</span>`;
                     found = true;
                     break;
                 }
@@ -1607,7 +1624,7 @@ function showProjectDetails(projectId) {
                 if (bestDist <= 2 && bestId) {
                     part = inventory[bestId];
                     matchedId = bestId;
-                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${part.name})</span>`;
+                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${escapeHtml(part.name)})</span>`;
                 }
             }
         }
@@ -1850,7 +1867,7 @@ function createProjectFromBom(projectName, projectId, bom) {
                 if (normalizeValue(invId) === normId) {
                     part = inventory[invId];
                     matchedId = invId;
-                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${part.name})</span>`;
+                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${escapeHtml(part.name)})</span>`;
                     found = true;
                     break;
                 }
@@ -1868,7 +1885,7 @@ function createProjectFromBom(projectName, projectId, bom) {
                 if (bestDist <= 2 && bestId) {
                     part = inventory[bestId];
                     matchedId = bestId;
-                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${part.name})</span>`;
+                    fuzzyNote = `<span style='color:#EBCB8B;font-size:11px;'>(Auto-matched to: ${escapeHtml(part.name)})</span>`;
                 }
             }
         }
@@ -1881,7 +1898,7 @@ function createProjectFromBom(projectName, projectId, bom) {
                         <span class="status-icon status-error">
                             <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><line x1="15" y1="9" x2="9" y2="15" stroke="currentColor" stroke-width="2"/><line x1="9" y1="9" x2="15" y2="15" stroke="currentColor" stroke-width="2"/></svg>
                         </span>
-                        <strong>${bom[id].name}</strong>
+                        <strong>${escapeHtml(bom[id].name)}</strong>
                     </span>
                     <span class="bom-part-status">: Missing entirely (need ${bom[id].quantity})</span>
                 </li>
@@ -1896,7 +1913,7 @@ function createProjectFromBom(projectName, projectId, bom) {
                         <span class="status-icon status-warning">
                             <svg viewBox="0 0 24 24"><polygon points="12,2 22,21 2,21" fill="currentColor" opacity="0.15"/><rect x="11" y="10" width="2" height="5" fill="currentColor"/><rect x="11" y="17" width="2" height="2" fill="currentColor"/></svg>
                         </span>
-                        <strong>${bom[id].name}</strong>
+                        <strong>${escapeHtml(bom[id].name)}</strong>
                     </span>
                     <span class="bom-part-status">: Have ${have}, need ${bom[id].quantity}</span>
                 </li>
@@ -1909,7 +1926,7 @@ function createProjectFromBom(projectName, projectId, bom) {
                         <span class="status-icon status-success">
                             <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><polyline points="8 12.5 11 16 16 9" fill="none" stroke="currentColor" stroke-width="2"/></svg>
                         </span>
-                        <strong>${bom[id].name}</strong>
+                        <strong>${escapeHtml(bom[id].name)}</strong>
                     </span>
                     <span class="bom-part-status">: In stock (have ${part.quantity}, need ${bom[id].quantity})</span>
                 </li>
@@ -2136,15 +2153,18 @@ function showProjectManagementModal() {
         
         projectElement.innerHTML = `
             <div>
-                <strong>${project.name}</strong>
+                <strong>${escapeHtml(project.name)}</strong>
                 <div class="project-info">
                     ${taggedParts} parts tagged
                 </div>
             </div>
             <div>
-                <button onclick="showDeleteProjectModal('${projectId}')" class="project-delete-btn">Delete</button>
+                <button class="project-delete-btn">Delete</button>
             </div>
         `;
+        
+        projectElement.querySelector('.project-delete-btn')
+            .addEventListener('click', () => showDeleteProjectModal(projectId));
         
         projectList.appendChild(projectElement);
     }
@@ -2340,12 +2360,12 @@ function showAllProjectRequirements() {
             sectionHtml += `
                 <li class="requirements-list-item ${part.status}">
                     ${statusIcon}
-                    <span class="part-name">${part.name}</span>
+                    <span class="part-name">${escapeHtml(part.name)}</span>
                     <span class="part-qty-info">
                         Have: <b>${part.inventoryQty}</b> / Need: <b>${part.total}</b>
                         ${part.status !== 'sufficient' ? ` / Short: <b>${Math.max(0, part.total - part.inventoryQty)}</b>` : ''}
                     </span>
-                    <span class="part-usage" title="${escapeHtml(fullUsageText)}">[${truncatedUsage}]</span>
+                    <span class="part-usage" title="${escapeHtml(fullUsageText)}">[${escapeHtml(truncatedUsage)}]</span>
                 </li>
             `;
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third improvement branch (after #4 and #5). PedalVault renders user-controlled data (part names, custom part IDs, capacitor types, project names, imported BOM entries) into `innerHTML` templates, and much of it was unescaped. Since the app imports JSON/CSV files, a crafted file was a working attack vector: a part name like `<img src=x onerror=...>` executed script on render, and a part ID containing a quote broke out of inline `onclick="showEditPartModal('ID')"` handlers into arbitrary JS. Purchase links also accepted `javascript:` URLs that executed on click.

### Commit 1 — Escaping and event wiring

- **`escapeHtml()` now escapes single and double quotes** in addition to `<`, `>`, `&`, so escaped values are safe inside attribute values (`title="..."`), not just text nodes. The previous DOM-based implementation left quotes unescaped.
- **Escaped every user-controlled interpolation** found in an exhaustive audit of all ~20 `innerHTML` sinks: inventory rows (type pill, project tags), add/edit-part modal project rows, BOM comparison results, the project management list, the all-project-requirements list, and the currently-unrendered fuzzy-match notes (latent footgun).
- **Capacitor type CSS class** restricted to `[a-z0-9_-]` (the type string was previously dropped raw into a `class` attribute).
- **Removed every inline `onclick` that embedded dynamic data.** Inventory edit/delete/shop buttons and project delete buttons now use `addEventListener` with the ID captured in a closure; the modal +/- quantity buttons use a delegated handler on the section container (assigned via `.onclick` so repeated modal opens don't stack listeners). Static inline handlers (fixed function names, no data) are unchanged.
- Removed `adjustProjectQty`/`adjustNewProjectQty`, now unused — they also interpolated IDs into `querySelector` template strings.

### Commit 2 — Purchase URL validation

- New `sanitizePurchaseUrl()`: only `http:`/`https:` URLs pass; `javascript:`, `data:`, `vbscript:`, `file:` etc. are rejected. Scheme-less input like `www.mouser.com/x` gets `https://` prepended (the old code stored it as-is, which produced a broken relative link when clicked).
- Applied at every write path: add part, edit part, inventory import (JSON and CSV), and add-missing-parts-from-BOM.
- `handlePurchaseClick()` re-validates at click time — this also protects users whose stored data predates this change — and opens links with `noopener`.

### Not in scope (deliberately)

Tightening the CSP by removing `script-src 'unsafe-inline'` would require moving all the *static* inline handlers and inline scripts out of `index.html`. All *dynamic* injection points are gone as of this PR; the CSP change is a larger mechanical refactor left for a future branch.

## Testing

- **Unit** (Node vm): 16 assertions on `escapeHtml` (quotes, angle brackets, non-strings) and `sanitizePurchaseUrl`/`sanitizeImportedPurchaseUrls` (https pass, javascript:/data:/vbscript:/file: blocked, case tricks blocked, scheme-less input upgraded). All pass.
- **End-to-end in real Chrome** (puppeteer, app served locally with malicious localStorage seeded before load): part name/type/project-name/ID payloads with `onerror`/`onload` handlers, a quote-breaking part ID, and a `javascript:` purchase URL. Verified: **no payload executes anywhere in the flow**, malicious names render as literal text with no injected elements, and the UI still works with hostile IDs — edit modal opens the right part, +/- buttons work on rows and in modals, delete confirmation targets the right project, the `javascript:` link is blocked with a user-facing error, and a legitimate `https:` link still opens. 19 assertions, all pass, zero page errors.
- **Baseline comparison**: the same e2e suite run against unmodified `main` fails — the type payload executes (`window.__PWNED_TYPE=1`), an injected `<img>` lands in the DOM, and the edit modal can't open for the quote-breaking ID — confirming both the vulnerabilities and the fix.

Test harnesses are throwaway scripts (repo has no test infrastructure yet).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f29-da8f-7986-9825-da90ccf32040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f29-da8f-7986-9825-da90ccf32040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

